### PR TITLE
Use auto to determine the iterator type in New

### DIFF
--- a/libraries/RungeKuttaSchemes/RungeKuttaScheme/RungeKuttaSchemeNew.C
+++ b/libraries/RungeKuttaSchemes/RungeKuttaScheme/RungeKuttaSchemeNew.C
@@ -17,7 +17,7 @@ Foam::autoPtr<Foam::RungeKuttaScheme> Foam::RungeKuttaScheme::New
 
     Info<< "Selecting Runge-Kutta scheme " << schemeName << endl;
 
-    dictionaryConstructorTable::iterator cstrIter =
+    auto cstrIter =
         dictionaryConstructorTablePtr_->find(schemeName);
 
     if (cstrIter == dictionaryConstructorTablePtr_->end())


### PR DESCRIPTION
Makes the library compile with v2112. Should be very safe, I guess. I tested also with v2106.