### PR TITLE
Allow passing -j to Allwmake

### DIFF
--- a/Allwmake
+++ b/Allwmake
@@ -1,4 +1,5 @@
 #!/bin/bash
+. "${WM_PROJECT_DIR:?}"/wmake/scripts/AllwmakeParseArguments
 
 wmake libso libraries/RungeKuttaSchemes
 


### PR DESCRIPTION
This allows you to do `./Allwmake -j`, which will then use all cores to compile the library. Makes it super fast. Stole it from swak4foam at some point for my library :-).