### PR TITLE
Fix in Ascher222 scheme

### DIFF
--- a/libraries/RungeKuttaSchemes/Ascher222/Ascher222.C
+++ b/libraries/RungeKuttaSchemes/Ascher222/Ascher222.C
@@ -25,8 +25,8 @@ Foam::RungeKuttaSchemes::Ascher222::Ascher222
 :
     RungeKuttaScheme(mesh, U, phi, p)
 {
-    a_.setSize(4, scalarList(4, 0.0));
-    b_.setSize(4, scalarList(4, 0.0));
+    a_.setSize(3, scalarList(3, 0.0));
+    b_.setSize(3, scalarList(3, 0.0));
 
     const scalar gamma(1.0-Foam::sqrt(2.0)/2.0);
     const scalar delta(1.0-0.5/gamma);
@@ -36,16 +36,10 @@ Foam::RungeKuttaSchemes::Ascher222::Ascher222
     a_[2][0] = delta;
     a_[2][1] = 1.0-delta;
 
-    a_[3][0] = delta;
-    a_[3][1] = 1.0-delta;
-
     b_[1][1] = gamma;
 
     b_[2][1] = 1.0-gamma;
     b_[2][2] = gamma;
-
-    b_[3][1] = 1.0-gamma;
-    b_[3][2] = gamma;
 
     init();
 }


### PR DESCRIPTION
If I'm not mistaken, since the last stage in the Ascher222 scheme (as currently implemented) equals the second-to-last stage, the last stage is redundant and can thus be removed.